### PR TITLE
feat: enable multi-step execution

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -106,6 +106,7 @@ Svara alltid på svenska och fokusera på affärsnytta och konkreta rekommendati
     const result = streamText({
       model: openai('gpt-4o'),
       messages: convertToModelMessages(messages),
+      maxSteps: 2,
       tools: {
         // Use CFO Orchestrator for complex requests
         processWithCFOOrchestrator: tool({


### PR DESCRIPTION
## Summary
- allow chat endpoint to continue after tool calls by setting maxSteps to 2

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68b8caa60fd8832d969f6319ee0bed3a